### PR TITLE
Package catch-the-bunny.0.0.2

### DIFF
--- a/packages/catch-the-bunny/catch-the-bunny.0.0.2/opam
+++ b/packages/catch-the-bunny/catch-the-bunny.0.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Resolving a small logic puzzle"
+maintainer: ["Mathieu Barbin"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/catch-the-bunny"
+doc: "https://mbarbin.github.io/catch-the-bunny/"
+bug-reports: "https://github.com/mbarbin/catch-the-bunny/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "5.1"}
+  "base" {>= "v0.16" & < "v0.17"}
+  "bisect_ppx" {dev & >= "2.8"}
+  "expect_test_helpers_core" {with-test & >= "v0.16" & < "v0.17"}
+  "ppx_jane" {>= "v0.16" & < "v0.17"}
+  "ppx_js_style" {>= "v0.16" & < "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/catch-the-bunny.git"
+url {
+  src:
+    "https://github.com/mbarbin/catch-the-bunny/releases/download/0.0.2/catch-the-bunny-0.0.2.tbz"
+  checksum: [
+    "sha256=a5b96e7db4eb53e3bb6a352a6e8b0711eed01608c7433730acffaf4b960f6093"
+    "sha512=b445bfa14a84979c46ba24938576e143363b339ebbb7df0e3074b9dbe1be404a2ffc773ffdac72a0e093085655483aa0c029aa9d293c5375d5b623051cd84dfc"
+  ]
+}
+x-commit-hash: "96fd2010625f2e9256fd6cb0540b93d053e505d7"


### PR DESCRIPTION
### `catch-the-bunny.0.0.2`
Resolving a small logic puzzle



---
* Homepage: https://github.com/mbarbin/catch-the-bunny
* Source repo: git+https://github.com/mbarbin/catch-the-bunny.git
* Bug tracker: https://github.com/mbarbin/catch-the-bunny/issues

---
:camel: Pull-request generated by opam-publish v2.3.0